### PR TITLE
Rework the Engine using Actions and add Disaster/Prevention Cards

### DIFF
--- a/Homestead/Client/Pages/GameBoardPage.razor
+++ b/Homestead/Client/Pages/GameBoardPage.razor
@@ -9,6 +9,6 @@
 @code {
     protected override void OnInitialized()
     {
-        Console.WriteLine("Got to the Game Board Page");
+        //Console.WriteLine("Got to the Game Board Page");
     }
 }

--- a/Homestead/Client/Shared/Components/DeckPile.razor
+++ b/Homestead/Client/Shared/Components/DeckPile.razor
@@ -15,7 +15,7 @@
 
     private void click()
     {
-        if (Lobby.Board.CanDrawFromDeck)
+        if (Lobby.Board.CanDrawFromDeck && Lobby.Board.State == Game.GameState.Playing)
         {
             Lobby.Board.DrawFromDeck();
         }

--- a/Homestead/Client/Shared/Components/GameBoard.razor
+++ b/Homestead/Client/Shared/Components/GameBoard.razor
@@ -37,7 +37,7 @@
     }
 </div>
 
-<div class="last-play">
+<div class="last-play @(Lobby.Board.IsLastPlayDisaster ? "last-play-disaster" : "")">
     @Lobby.Board.LastPlayText
 </div>
 

--- a/Homestead/Client/Shared/Components/GameBoard.razor
+++ b/Homestead/Client/Shared/Components/GameBoard.razor
@@ -37,6 +37,10 @@
     }
 </div>
 
+<div class="last-play">
+    @Lobby.Board.LastPlayText
+</div>
+
 <div class="player-hand">
     <DeckPile CanDraw="@(Board.CanDrawFromDeck && Board.State == Game.GameState.Playing)"></DeckPile>
     <DiscardPile Card="@Board.TopDiscardCard" CanDraw="@Board.CanDrawFromDiscard"></DiscardPile>

--- a/Homestead/Client/Shared/Components/GameBoard.razor
+++ b/Homestead/Client/Shared/Components/GameBoard.razor
@@ -23,7 +23,7 @@
     @if (IsOwnerOfGame && Board.State == Game.GameState.Joining)
     {
         <div class="row justify-content-md-center">
-            <button type="button" class="btn btn-success btn-lg col-sm" @onclick="StartGame">Start</button>
+            <button type="button" class="btn btn-primary btn-lg col-sm" @onclick="StartGame">Start</button>
         </div>
     }
     else if (Board.State == Game.GameState.Complete && Board.WinningPlayer != null)
@@ -81,25 +81,25 @@
         Console.WriteLine($"Game Board Component with {Opponents.Count() + 1} Players");
         hubConnection.On<Game>("ExecuteAction", (game) =>
         {
-            Console.WriteLine("Got Game Update");
+            //Console.WriteLine("Got Game Update");
             foreach (var action in game.LastActions)
             {
                 Console.WriteLine($"Last Action: {action.Type}");
             }
             Board.Update(game);
-            Console.WriteLine(Board.LocalPlayer.ToString());
+            //Console.WriteLine(Board.LocalPlayer.ToString());
             foreach (var player in Board.OtherPlayers)
             {
                 Console.WriteLine(player);
             }
-            if (Board.CanDrawFromDeck) Console.WriteLine("Can Draw from Deck");
-            if (Board.CanDrawFromDiscard) Console.WriteLine("Can Draw from Discard");
+            //if (Board.CanDrawFromDeck) Console.WriteLine("Can Draw from Deck");
+            //if (Board.CanDrawFromDiscard) Console.WriteLine("Can Draw from Discard");
 
             foreach (var action in game.AvailableActions)
             {
                 Console.WriteLine($"Available Action: {action.Type}");
             }
-            Console.WriteLine($"Cards: Hand: {Board.LocalPlayer.Hand.Count}  Board: {Board.LocalPlayer.Board.Count}");
+            Console.WriteLine($"Player Cards: Hand: {Board.LocalPlayer.Hand.Count}  Board: {Board.LocalPlayer.Board.Count}");
             StateHasChanged();
         });
         Board.PerformAction += SendActionEvent!;

--- a/Homestead/Client/Shared/Components/PlayerHomestead.razor
+++ b/Homestead/Client/Shared/Components/PlayerHomestead.razor
@@ -36,6 +36,7 @@
             <!-- Garden -->
             <img class="garden" src="/Assets/Images/garden/garden@(Player.BoardGarden.Count()).png" />
         </div>
+
     </div>
     <!-- Card Slots -->
     <div class="row board-cards">

--- a/Homestead/Client/Shared/Components/PlayerHomestead.razor
+++ b/Homestead/Client/Shared/Components/PlayerHomestead.razor
@@ -32,7 +32,7 @@
             <!-- House -->
             <img class="home" src="/Assets/Images/house/house@(Player.BoardHouse.Count()).png" />
             <!-- Player -->
-            <img class="player" src="@Player.GetImageUrl()" />
+            <img class="player @(Lobby.Board.CanSelectPlayer ? "selected":"")" src="@Player.GetImageUrl()" @onclick="SelectPlayer"/>
             <!-- Garden -->
             <img class="garden" src="/Assets/Images/garden/garden@(Player.BoardGarden.Count()).png" />
         </div>
@@ -100,6 +100,11 @@
     protected override void OnInitialized()
     {
         Console.WriteLine($"Player {Player.PlayerNumber}");
+    }
+
+    protected void SelectPlayer()
+    {
+        Lobby.Board.SelectPlayer(Player.PlayerNumber);
     }
 
 

--- a/Homestead/Client/ViewModels/BoardVm.cs
+++ b/Homestead/Client/ViewModels/BoardVm.cs
@@ -71,11 +71,11 @@ namespace Homestead.Client.ViewModels
 
         public void SelectPlayer(int playerNumber)
         {
-            PlayerAction action = new(PlayerAction.ActionType.Play, LocalPlayerNumber,SelectedCard, playerNumber);
+            PlayerAction action = new(PlayerAction.ActionType.Play, LocalPlayerNumber, SelectedCard, playerNumber);
             OnPerformAction(action);
         }
 
-
+        public string? LastPlayText { get; internal set; } = string.Empty;
 
 
         public BoardVm(Game game, int localPlayerNumber)
@@ -195,6 +195,15 @@ namespace Homestead.Client.ViewModels
                 }
             }
 
+            // Set LastPlayText
+            if (game.LastActions.Any())
+            {
+                LastPlayText = string.Join(Environment.NewLine, game.LastActions.Select(f => f.ToString(game)));
+            }
+            else
+            {
+                LastPlayText = string.Empty;
+            }
         }
     }
 }

--- a/Homestead/Client/ViewModels/BoardVm.cs
+++ b/Homestead/Client/ViewModels/BoardVm.cs
@@ -75,8 +75,8 @@ namespace Homestead.Client.ViewModels
             OnPerformAction(action);
         }
 
-        public string? LastPlayText { get; internal set; } = string.Empty;
-
+        public string? LastPlayText { get; private set; } = string.Empty;
+        public bool IsLastPlayDisaster { get; private set; }
 
         public BoardVm(Game game, int localPlayerNumber)
         {
@@ -199,10 +199,12 @@ namespace Homestead.Client.ViewModels
             if (game.LastActions.Any())
             {
                 LastPlayText = string.Join(Environment.NewLine, game.LastActions.Select(f => f.ToString(game)));
+                IsLastPlayDisaster = game.LastActions.Any(game=> game.IsDisaster);
             }
             else
             {
                 LastPlayText = string.Empty;
+                IsLastPlayDisaster = false;
             }
         }
     }

--- a/Homestead/Client/wwwroot/css/app.css
+++ b/Homestead/Client/wwwroot/css/app.css
@@ -70,6 +70,13 @@ div.page {
         width: 50px;
     }
 
+div.last-play {
+    min-height: 26px;
+}
+div.last-play.last-play-disaster{
+    background-color: pink;
+    font-weight: bold;
+}
 
 
 .deck-pile {

--- a/Homestead/Client/wwwroot/css/app.css
+++ b/Homestead/Client/wwwroot/css/app.css
@@ -14,19 +14,21 @@ img {
     image-rendering: pixelated;
 }
 
-.tree-background{
+.tree-background {
     background-image: url("/Assets/Images/map.png");
     background-size: 30%;
     background-position: -40px -40px;
 }
-.green-background{
+
+.green-background {
     background-color: #CCDDCC;
 }
 
 div.navbar div.pinewood a.navbar-brand, .brown {
     color: #432900;
 }
-    div.navbar  div.pinewood a.navbar-brand:hover {
+
+    div.navbar div.pinewood a.navbar-brand:hover {
         color: #533910;
     }
 
@@ -39,9 +41,9 @@ div.page {
 @font-face {
     font-family: Pinewood;
     src: url('/Assets/Fonts/Pinewood.ttf');
-} 
-.pinewood
-{
+}
+
+.pinewood {
     font-family: Pinewood;
 }
 
@@ -73,10 +75,11 @@ div.page {
 div.last-play {
     min-height: 26px;
 }
-div.last-play.last-play-disaster{
-    background-color: pink;
-    font-weight: bold;
-}
+
+    div.last-play.last-play-disaster {
+        background-color: pink;
+        font-weight: bold;
+    }
 
 
 .deck-pile {
@@ -192,11 +195,12 @@ div, img {
     border: 1px solid transparent;
 }
 
-.homestead-outline.selected{
+.homestead-outline.selected {
     border: 4px solid rgba(150,100,100,.7);
     background-color: rgba(255,255,255,.1)
 }
-.homestead-outline{
+
+.homestead-outline {
     border: 4px solid transparent;
 }
 

--- a/Homestead/Homestead.Client.Tests/GameVmTest.cs
+++ b/Homestead/Homestead.Client.Tests/GameVmTest.cs
@@ -9,7 +9,7 @@ namespace Homestead.Client.Tests
         [TestMethod]
         public void Create()
         {
-            var game = (new GameEngine()).Start("test");
+            var game = (new GameEngineWithActions()).Start("test");
 
             var board = new BoardVm(game,2);
             Assert.AreEqual(2, board.LocalPlayer.PlayerNumber);
@@ -20,7 +20,7 @@ namespace Homestead.Client.Tests
 
         public void UpdateWhenPlayersTurn()
         {
-            var game = (new GameEngine()).Start("test");
+            var game = (new GameEngineWithActions()).Start("test");
             var board = new BoardVm(game, 2);
 
             // Update the game
@@ -54,7 +54,7 @@ namespace Homestead.Client.Tests
 
         public void UpdateWhenNotPlayersTurn()
         {
-            var game = (new GameEngine()).Start("test");
+            var game = (new GameEngineWithActions()).Start("test");
             var board = new BoardVm(game, 2);
             
             // Update the game

--- a/Homestead/Homestead.Shared.Tests/GameEngineTest.cs
+++ b/Homestead/Homestead.Shared.Tests/GameEngineTest.cs
@@ -8,9 +8,9 @@ namespace Homestead.Shared.Tests
         // Do test setup!
         [TestMethod]
         public void StartGameTest()
-        { 
+        {
             // break this test up
-            GameEngine engine = new();
+            GameEngineWithActions engine = new();
             Game game = engine.Start("test");
             Assert.IsNotNull(game);
             Assert.IsFalse(string.IsNullOrEmpty(game.GameId));
@@ -25,7 +25,7 @@ namespace Homestead.Shared.Tests
         [TestMethod]
         public void DrawFromDeckTest()
         {
-            GameEngine engine = new();
+            GameEngineWithActions engine = new();
             Game game = engine.Start("test");
 
             game = engine.ProcessAction(game, new PlayerAction(PlayerAction.ActionType.DrawFromDeck, game.ActivePlayer));
@@ -42,7 +42,7 @@ namespace Homestead.Shared.Tests
         [Ignore]
         public void DiscardCardTest()
         {
-            GameEngine engine = new();
+            GameEngineWithActions engine = new();
             Game game = engine.Start("test");
 
             PlayerAction action = new(PlayerAction.ActionType.Discard, game.ActivePlayer, Cards.Well);
@@ -61,7 +61,7 @@ namespace Homestead.Shared.Tests
         [Ignore]
         public void DrawFromDiscardTest()
         {
-            GameEngine engine = new();
+            GameEngineWithActions engine = new();
             Game game = engine.Start("test");
 
             PlayerAction action = new(PlayerAction.ActionType.DrawFromDiscard, game.ActivePlayer);
@@ -86,7 +86,7 @@ namespace Homestead.Shared.Tests
         [Ignore]
         public void DrawFromDiscardWhenMultipleOfSameTypeExist()
         {
-            GameEngine engine = new();
+            GameEngineWithActions engine = new();
             Game game = engine.Start("test");
 
             PlayerAction action = new(PlayerAction.ActionType.DrawFromDiscard, game.ActivePlayer);
@@ -109,7 +109,7 @@ namespace Homestead.Shared.Tests
         [TestMethod]
         public void PlayCard()
         {
-            GameEngine engine = new();
+            GameEngineWithActions engine = new();
             Game game = engine.Start("test");
 
             game.Players[game.ActivePlayer-1].Hand.Add(Cards.Well);
@@ -124,7 +124,7 @@ namespace Homestead.Shared.Tests
         [TestMethod]
         public void PlayCardWithoutCardInHandThrowsKeyNotFound()
         {
-            GameEngine engine = new();
+            GameEngineWithActions engine = new();
             Game game = engine.Start("test");
 
             PlayerAction action = new(PlayerAction.ActionType.Play, game.ActivePlayer);
@@ -140,7 +140,7 @@ namespace Homestead.Shared.Tests
         [Ignore]
         public void PlayCardGiveCard()
         {
-            GameEngine engine = new();
+            GameEngineWithActions engine = new();
             Game game = engine.Start("test");
             game.Players.Add(new Player());
 
@@ -165,7 +165,7 @@ namespace Homestead.Shared.Tests
         [Ignore]
         public void PlayCardGiveCardWithoutAdditionalCardInHand()
         {
-            GameEngine engine = new();
+            GameEngineWithActions engine = new();
             Game game = engine.Start("test");
             game.Players.Add(new Player());
 
@@ -186,7 +186,7 @@ namespace Homestead.Shared.Tests
         [Ignore]
         public void PlayCardStealCard()
         {
-            GameEngine engine = new();
+            GameEngineWithActions engine = new();
             Game game = engine.Start("test");
             game.Players.Add(new Player());
 
@@ -217,7 +217,7 @@ namespace Homestead.Shared.Tests
         [Ignore]
         public void CannotEndTurn1()
         {
-            GameEngine engine = new();
+            GameEngineWithActions engine = new();
             Game game = engine.Start("test");
 
             game.Players[game.ActivePlayer].Hand.Add(Cards.Well);
@@ -234,7 +234,7 @@ namespace Homestead.Shared.Tests
         [Ignore]
         public void Wolves()
         {
-            GameEngine engine = new();
+            GameEngineWithActions engine = new();
             Game game = engine.Start("test");
             game.AvailableActions.Clear();
 
@@ -251,7 +251,7 @@ namespace Homestead.Shared.Tests
         [Ignore]
         public void GameTest()
         {
-            GameEngine engine = new();
+            GameEngineWithActions engine = new();
             Game game = engine.Start("test");
 
             game = engine.ProcessAction(game, game.AvailableActions.First());

--- a/Homestead/Homestead.Shared.Tests/GameTest.cs
+++ b/Homestead/Homestead.Shared.Tests/GameTest.cs
@@ -6,7 +6,7 @@ namespace Homestead.Shared.Tests
         [TestMethod]
         public void CreateGame()
         {
-            GameEngine engine = new();
+            GameEngineWithActions engine = new();
             Game game = engine.Start("test");
 
             Assert.AreEqual(4, game.Players.Count);

--- a/Homestead/Server/Program.cs
+++ b/Homestead/Server/Program.cs
@@ -10,7 +10,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();
 builder.Services.AddSignalR();
-builder.Services.AddSingleton<IGameEngine, GameEngine>();
+builder.Services.AddSingleton<IGameEngine, GameEngineWithActions>();
 builder.Services.AddSingleton<IGameLookup, GameLookup>();
 
 builder.Services.AddSwaggerGen();

--- a/Homestead/Server/SignalR/CommunicationHub.cs
+++ b/Homestead/Server/SignalR/CommunicationHub.cs
@@ -34,6 +34,7 @@ public class CommunicationHub : Hub
             Random rand = new Random();
             int index = rand.Next(0, newState.AvailableActions.Count - 1);
             var newAction = newState.AvailableActions[index];
+            // TODO: Move logic into ActionBase class
             if (newAction.Type is PlayerAction.ActionType.Discard
                 && string.IsNullOrWhiteSpace(newAction.PlayerCard))
             {

--- a/Homestead/Server/SignalR/CommunicationHub.cs
+++ b/Homestead/Server/SignalR/CommunicationHub.cs
@@ -24,7 +24,7 @@ public class CommunicationHub : Hub
         }
         var newState = engine.ProcessAction(game, action);
         await Clients.Group(newState.GameId).SendAsync("ExecuteAction", newState);
-        while (newState.Players[newState.ActivePlayer-1].IsBot)
+        while (newState.Players[newState.ActivePlayer - 1].IsBot)
         {
             if (game.State is Game.GameState.Complete)
             {
@@ -45,7 +45,7 @@ public class CommunicationHub : Hub
             await Clients.Group(newState.GameId).SendAsync("ExecuteAction", newState);
         }
     }
-    
+
     public async Task RequestPushGameState(string gameId)
     {
         var game = gameLookup.GetGame(gameId);

--- a/Homestead/Server/SignalR/CommunicationHub.cs
+++ b/Homestead/Server/SignalR/CommunicationHub.cs
@@ -43,6 +43,11 @@ public class CommunicationHub : Hub
 
             newState = engine.ProcessAction(newState, newAction);
             await Clients.Group(newState.GameId).SendAsync("ExecuteAction", newState);
+            // If a bot played a disaster card, wait more time so players know what happened.
+            if (newAction.Type == PlayerAction.ActionType.Play && Cards.GetCardInfo(newAction.PlayerCard!).Suit == CardInfo.CardSuit.Disaster)
+            {
+                await Task.Delay(2000).ConfigureAwait(false);
+            }
         }
     }
 

--- a/Homestead/Shared/Actions/ActionBase.cs
+++ b/Homestead/Shared/Actions/ActionBase.cs
@@ -33,8 +33,8 @@ namespace Homestead.Shared.Actions
         internal void SetNextActionsFromHand()
         {
             ClearActions();
-            // See if the player has a new disaster card and force them to play it.
-            foreach (var card in CurrentPlayer.Hand.Where(f => Cards.GetCardInfo(f).Suit == CardInfo.CardSuit.Disaster))
+            // See if the player has a new disaster card that applies to them self, force them to play it.
+            foreach (var card in CurrentPlayer.Hand.Where(f => Cards.GetCardInfo(f).Suit == CardInfo.CardSuit.Disaster && Cards.GetCardInfo(f).Impact != CardInfo.CardImpact.Other))
             {
                 AddAction(PlayerAction.ActionType.Play, card);
             }
@@ -66,6 +66,11 @@ namespace Homestead.Shared.Actions
                     }
                     // See if there are action plays
                     foreach (var card in CurrentPlayer.Hand.Where(f => Cards.GetCardInfo(f).Suit == CardInfo.CardSuit.Action))
+                    {
+                        AddAction(PlayerAction.ActionType.Play, card);
+                    }
+                    // See if there are disaster plays
+                    foreach (var card in CurrentPlayer.Hand.Where(f => Cards.GetCardInfo(f).Suit == CardInfo.CardSuit.Disaster))
                     {
                         AddAction(PlayerAction.ActionType.Play, card);
                     }

--- a/Homestead/Shared/Actions/ActionBase.cs
+++ b/Homestead/Shared/Actions/ActionBase.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static Homestead.Shared.PlayerAction;
+
+namespace Homestead.Shared.Actions
+{
+    public abstract class ActionBase
+    {
+        public Game Game { get; }
+        public ActionBase(Game game)
+        {
+            Game = game;
+        }
+
+        public PlayerAction.ActionType Type { get; internal set; }
+
+        public abstract void Run(PlayerAction action);
+
+        internal Player CurrentPlayer
+        {
+            get
+            {
+                return Game.Players[Game.ActivePlayer - 1];
+            }
+        }
+
+        /// <summary>
+        /// Call this when the player can play from their hand or end their turn.
+        /// </summary>
+        internal void SetNextActionsFromHand()
+        {
+            // See if the player has a new disaster card and force them to play it.
+            foreach (var card in CurrentPlayer.Hand.Where(f => Cards.GetCardInfo(f).Suit == CardInfo.CardSuit.Disaster))
+            {
+                AddAction(PlayerAction.ActionType.Play, card);
+            }
+
+            // If there are no required disaster card plays then see if there is a forced play to the board.
+            if (!Game.AvailableActions.Any())
+            {
+                // See if the player is forced to play a card
+                // Also check for possible discards
+                List<string> discards = new();
+                foreach (var card in CurrentPlayer.Hand.Where(f => Cards.GetCardInfo(f).RequiredToWin))
+                {
+                    if (!CurrentPlayer.Board.Contains(card))
+                    {
+                        AddAction(PlayerAction.ActionType.Play, card);
+                    }
+                    else
+                    {
+                        discards.Add(card);
+                    }
+                }
+                // There are no required plays see about optional ones.
+                if (!Game.AvailableActions.Any())
+                {
+                    // Add the valid discards
+                    foreach (var card in discards)
+                    {
+                        AddAction(PlayerAction.ActionType.Discard, card);
+                    }
+                    // See if there are action plays
+                    foreach (var card in CurrentPlayer.Hand.Where(f => Cards.GetCardInfo(f).Suit == CardInfo.CardSuit.Action))
+                    {
+                        AddAction(PlayerAction.ActionType.Play, card);
+                    }
+                    // The player should also be able to end their turn if they don't have 5 cards
+                    if (CurrentPlayer.Hand.Count < 5)
+                    {
+                        AddAction(ActionType.EndTurn);
+                    }
+                }
+            }
+        }
+
+        internal void AddAction(ActionType type, string? PlayerCard = null, int? TargetPlayer = null, string? TargetCard = null)
+        {
+            Game.AvailableActions.Add(new PlayerAction(type, Game.ActivePlayer, PlayerCard, TargetPlayer, TargetCard));
+        }
+    }
+}
+

--- a/Homestead/Shared/Actions/ActionBase.cs
+++ b/Homestead/Shared/Actions/ActionBase.cs
@@ -32,6 +32,7 @@ namespace Homestead.Shared.Actions
         /// </summary>
         internal void SetNextActionsFromHand()
         {
+            ClearActions();
             // See if the player has a new disaster card and force them to play it.
             foreach (var card in CurrentPlayer.Hand.Where(f => Cards.GetCardInfo(f).Suit == CardInfo.CardSuit.Disaster))
             {
@@ -80,6 +81,10 @@ namespace Homestead.Shared.Actions
         internal void AddAction(ActionType type, string? PlayerCard = null, int? TargetPlayer = null, string? TargetCard = null)
         {
             Game.AvailableActions.Add(new PlayerAction(type, Game.ActivePlayer, PlayerCard, TargetPlayer, TargetCard));
+        }
+        internal void ClearActions()
+        {
+            Game.AvailableActions.Clear();
         }
     }
 }

--- a/Homestead/Shared/Actions/ActionBase.cs
+++ b/Homestead/Shared/Actions/ActionBase.cs
@@ -64,6 +64,11 @@ namespace Homestead.Shared.Actions
                     {
                         AddAction(PlayerAction.ActionType.Discard, card);
                     }
+                    // Add discard of prevention cards
+                    foreach (var card in CurrentPlayer.Hand.Where(c=>Cards.GetCardInfo(c).Suit == CardInfo.CardSuit.Prevention))
+                    {
+                        AddAction(PlayerAction.ActionType.Discard, card);
+                    }
                     // See if there are action plays
                     foreach (var card in CurrentPlayer.Hand.Where(f => Cards.GetCardInfo(f).Suit == CardInfo.CardSuit.Action))
                     {

--- a/Homestead/Shared/Actions/ActionDiscardCard.cs
+++ b/Homestead/Shared/Actions/ActionDiscardCard.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Homestead.Shared.Actions
+{
+    public class ActionDiscardCard : ActionBase
+    {
+        public ActionDiscardCard(Game game): base(game)
+        {
+            Type = PlayerAction.ActionType.Discard;
+        }
+        
+        public override void Run(PlayerAction action)
+        {
+            if (action.PlayerCard is not null)
+            {
+                CurrentPlayer.Hand.Remove(action.PlayerCard);
+                Game.DiscardPile.Add(action.PlayerCard);
+            }
+            else
+            {
+                throw new Exception("No card specified");
+            }
+
+            // Determine what can happen next
+            SetNextActionsFromHand();
+        }
+    }
+}
+

--- a/Homestead/Shared/Actions/ActionDrawCard.cs
+++ b/Homestead/Shared/Actions/ActionDrawCard.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Homestead.Shared.Actions
+{
+    public class ActionDrawCard : ActionBase
+    {
+        public ActionDrawCard(Game game): base(game)
+        {
+            Type = PlayerAction.ActionType.DrawFromDeck;
+        }
+        
+        public override void Run(PlayerAction action)
+        {
+            CurrentPlayer.Hand.Add(Cards.GetCard());
+
+            // Determine what can happen next
+            SetNextActionsFromHand();
+        }
+    }
+}
+

--- a/Homestead/Shared/Actions/ActionDrawDeckCard.cs
+++ b/Homestead/Shared/Actions/ActionDrawDeckCard.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Homestead.Shared.Actions
+{
+    public class ActionDrawDeckCard : ActionBase
+    {
+        public ActionDrawDeckCard(Game game): base(game)
+        {
+            Type = PlayerAction.ActionType.DrawFromDeck;
+        }
+        
+        public override void Run(PlayerAction action)
+        {
+            CurrentPlayer.Hand.Add(Cards.GetCard());
+
+            // Determine what can happen next
+            SetNextActionsFromHand();
+        }
+    }
+}
+

--- a/Homestead/Shared/Actions/ActionDrawDiscardCard.cs
+++ b/Homestead/Shared/Actions/ActionDrawDiscardCard.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Homestead.Shared.Actions
+{
+    public class ActionDrawDiscardCard : ActionBase
+    {
+        public ActionDrawDiscardCard(Game game): base(game)
+        {
+            Type = PlayerAction.ActionType.DrawFromDeck;
+        }
+        
+        public override void Run(PlayerAction action)
+        {
+            if (Game.DiscardPile.Count > 0)
+            {
+                var card = Game.DiscardPile[Game.DiscardPile.Count - 1];
+                Game.DiscardPile.RemoveAt(Game.DiscardPile.Count - 1);
+                CurrentPlayer.Hand.Add(card);
+            }
+            else
+            {
+                throw new Exception("Invalid Action, no cards in discard pile");
+            }
+
+            // Determine what can happen next
+            SetNextActionsFromHand();
+        }
+    }
+}
+

--- a/Homestead/Shared/Actions/ActionEndTurn.cs
+++ b/Homestead/Shared/Actions/ActionEndTurn.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static Homestead.Shared.PlayerAction;
 
 namespace Homestead.Shared.Actions
 {
@@ -25,7 +26,11 @@ namespace Homestead.Shared.Actions
             }
 
             // Determine what can happen next
-            SetNextActionsFromHand();
+            AddAction(ActionType.DrawFromDeck);
+            if (Game.DiscardPile.Count() > 0)
+            {
+                AddAction(ActionType.DrawFromDiscard);
+            }
         }
     }
 }

--- a/Homestead/Shared/Actions/ActionEndTurn.cs
+++ b/Homestead/Shared/Actions/ActionEndTurn.cs
@@ -6,16 +6,23 @@ using System.Threading.Tasks;
 
 namespace Homestead.Shared.Actions
 {
-    public class ActionDrawCard : ActionBase
+    public class ActionEndTurn : ActionBase
     {
-        public ActionDrawCard(Game game): base(game)
+        public ActionEndTurn(Game game): base(game)
         {
-            Type = PlayerAction.ActionType.DrawFromDeck;
+            Type = PlayerAction.ActionType.EndTurn;
         }
         
         public override void Run(PlayerAction action)
         {
-            CurrentPlayer.Hand.Add(Cards.GetCard());
+            if (Game.ActivePlayer < 4)
+            {
+                Game.ActivePlayer++;
+            }
+            else
+            {
+                Game.ActivePlayer = 1;
+            }
 
             // Determine what can happen next
             SetNextActionsFromHand();

--- a/Homestead/Shared/Actions/ActionEndTurn.cs
+++ b/Homestead/Shared/Actions/ActionEndTurn.cs
@@ -16,6 +16,7 @@ namespace Homestead.Shared.Actions
         
         public override void Run(PlayerAction action)
         {
+            ClearActions();
             if (Game.ActivePlayer < 4)
             {
                 Game.ActivePlayer++;

--- a/Homestead/Shared/Actions/ActionPlayCard.cs
+++ b/Homestead/Shared/Actions/ActionPlayCard.cs
@@ -18,16 +18,24 @@ namespace Homestead.Shared.Actions
         {
             if (action.PlayerCard is not null)
             {
-                switch (Cards.GetCardInfo(action.PlayerCard).Suit)
+                // Make sure the player has the card
+                if (CurrentPlayer.Hand.Contains(action.PlayerCard))
                 {
-                    case CardInfo.CardSuit.House:
-                        PlayCardToBoard(action.PlayerCard); break;
-                    case CardInfo.CardSuit.LiveStock:
-                        PlayCardToBoard(action.PlayerCard); break;
-                    case CardInfo.CardSuit.Garden: PlayCardToBoard(action.PlayerCard); break;
-                    case CardInfo.CardSuit.Action: PerformAction(action.PlayerCard); break;
-                    case CardInfo.CardSuit.Disaster: DoDisaster(action.PlayerCard); break;
-                    default: throw new ArgumentException("Invalid card");
+                    switch (Cards.GetCardInfo(action.PlayerCard).Suit)
+                    {
+                        case CardInfo.CardSuit.House:
+                            PlayCardToBoard(action.PlayerCard); break;
+                        case CardInfo.CardSuit.LiveStock:
+                            PlayCardToBoard(action.PlayerCard); break;
+                        case CardInfo.CardSuit.Garden: PlayCardToBoard(action.PlayerCard); break;
+                        case CardInfo.CardSuit.Action: PerformAction(action.PlayerCard); break;
+                        case CardInfo.CardSuit.Disaster: DoDisaster(action.PlayerCard); break;
+                        default: throw new ArgumentException("Invalid card");
+                    }
+                }
+                else
+                {
+                    throw new KeyNotFoundException("Player doesn't have that card.");
                 }
             }
             // Determine what can happen next

--- a/Homestead/Shared/Actions/ActionPlayCard.cs
+++ b/Homestead/Shared/Actions/ActionPlayCard.cs
@@ -64,6 +64,7 @@ namespace Homestead.Shared.Actions
         private void DoDisaster(string card, int? targetPlayer)
         {
             var impactedCard = (Cards.GetCardInfo(card).ImpactedCard);
+            var preventionCard = (Cards.GetCardInfo(card).PreventionCard);
 
             if (impactedCard != null)
             {
@@ -72,18 +73,18 @@ namespace Homestead.Shared.Actions
                 {
                     case CardInfo.CardImpact.Self:
                         // See if I have the impacted card and remove it
-                        RemoveCardFromPlayersBoard(Game.ActivePlayer, impactedCard);
+                        RemoveCardsBasedOnDisaster(Game.ActivePlayer, impactedCard, preventionCard);
                         break;
                     case CardInfo.CardImpact.All:
-                        foreach(var player in Game.Players)
+                        foreach (var player in Game.Players)
                         {
-                            RemoveCardFromPlayersBoard(player.PlayerNumber, impactedCard);
+                            RemoveCardsBasedOnDisaster(player.PlayerNumber, impactedCard, preventionCard);
                         }
                         break;
                     case CardInfo.CardImpact.Other:
                         if (targetPlayer != null)
                         {
-                            RemoveCardFromPlayersBoard(targetPlayer.Value, impactedCard);
+                            RemoveCardsBasedOnDisaster(targetPlayer.Value, impactedCard, preventionCard);
                         }
                         else
                         {
@@ -104,19 +105,34 @@ namespace Homestead.Shared.Actions
             CurrentPlayer.Hand.Remove(card);
         }
 
-        private void RemoveCardFromPlayersBoard(int playerNumber, string card)
+        private bool RemoveCardsBasedOnDisaster(int playerNumber, string impactedCard, string preventionCard)
         {
+            if (preventionCard==null || !RemoveCardFromPlayersHand(playerNumber, preventionCard))
+            {
+                return RemoveCardFromPlayersBoard(playerNumber, impactedCard);
+            }
+            return true;
+        }
+
+        private bool RemoveCardFromPlayersBoard(int playerNumber, string card)
+        {
+
+            // Remove the impacted card from the board
             if (Game.Players[playerNumber - 1].Board.Contains(card))
             {
                 Game.Players[playerNumber - 1].Board.Remove(card);
+                return true;
             }
+            return false;
         }
-        private void RemoveCardFromPlayersHand(int playerNumber, string card)
+        private bool RemoveCardFromPlayersHand(int playerNumber, string card)
         {
             if (Game.Players[playerNumber - 1].Hand.Contains(card))
             {
                 Game.Players[playerNumber - 1].Hand.Remove(card);
+                return true;
             }
+            return false;
         }
     }
 }

--- a/Homestead/Shared/Actions/ActionPlayCard.cs
+++ b/Homestead/Shared/Actions/ActionPlayCard.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static System.Collections.Specialized.BitVector32;
+
+namespace Homestead.Shared.Actions
+{
+    public class ActionPlayCard : ActionBase
+    {
+        public ActionPlayCard(Game game) : base(game)
+        {
+            Type = PlayerAction.ActionType.Play;
+        }
+
+        public override void Run(PlayerAction action)
+        {
+            if (action.PlayerCard is not null)
+            {
+                switch (Cards.GetCardInfo(action.PlayerCard).Suit)
+                {
+                    case CardInfo.CardSuit.House:
+                        PlayCardToBoard(action.PlayerCard); break;
+                    case CardInfo.CardSuit.LiveStock:
+                        PlayCardToBoard(action.PlayerCard); break;
+                    case CardInfo.CardSuit.Garden: PlayCardToBoard(action.PlayerCard); break;
+                    case CardInfo.CardSuit.Action: PerformAction(action.PlayerCard); break;
+                    case CardInfo.CardSuit.Disaster: DoDisaster(action.PlayerCard); break;
+                    default: throw new ArgumentException("Invalid card");
+                }
+            }
+            // Determine what can happen next
+            SetNextActionsFromHand();
+        }
+
+        private void PlayCardToBoard(string card)
+        {
+            CurrentPlayer.Board.Add(card);
+            CurrentPlayer.Hand.Remove(card);
+            SetNextActionsFromHand();
+        }
+        private void PerformAction(string card)
+        {
+            // TODO: do stuff for each card
+            // Check which type of action it is and then add next actions
+
+
+            CurrentPlayer.Hand.Remove(card);
+        }
+        private void DoDisaster(string card)
+        {
+            // TODO: do the disaster
+            // Check which type of action it is and then add next actions
+
+
+
+            CurrentPlayer.Hand.Remove(card);
+        }
+    }
+}
+

--- a/Homestead/Shared/Actions/ActionPlayCard.cs
+++ b/Homestead/Shared/Actions/ActionPlayCard.cs
@@ -16,6 +16,7 @@ namespace Homestead.Shared.Actions
 
         public override void Run(PlayerAction action)
         {
+            Game.AvailableActions.Clear();
             if (action.PlayerCard is not null)
             {
                 // Make sure the player has the card

--- a/Homestead/Shared/Cards.cs
+++ b/Homestead/Shared/Cards.cs
@@ -61,9 +61,9 @@ namespace Homestead.Shared
             //MasterDeck.Add(new CardInfo(GoodNeighbor, "Give", CardInfo.CardSuit.Action, false, CardInfo.CardImpact.None, "good-neighbor", some));
             //MasterDeck.Add(new CardInfo(BadNeighbor, "Steal", CardInfo.CardSuit.Action, false, CardInfo.CardImpact.None, "bad-neighbor", some));
 
-            MasterDeck.Add(new CardInfo(Levee, "Levee", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "levee.png", tons));
-            MasterDeck.Add(new CardInfo(Dog, "D.O.G.", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "dog.png", tons));
-            MasterDeck.Add(new CardInfo(Rain, "Rain", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "rain.png", tons));
+            MasterDeck.Add(new CardInfo(Levee, "Levee", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "levee.png", lots));
+            MasterDeck.Add(new CardInfo(Dog, "D.O.G.", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "dog.png", lots));
+            MasterDeck.Add(new CardInfo(Rain, "Rain", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "rain.png", lots));
 
             MasterDeck.Add(new CardInfo(Livestock, "Animals", CardInfo.CardSuit.LiveStock, true, CardInfo.CardImpact.None, "livestock.png", lots));
             MasterDeck.Add(new CardInfo(Seeds, "Seeds", CardInfo.CardSuit.Garden, true, CardInfo.CardImpact.None, "seeds.png", lots));

--- a/Homestead/Shared/Cards.cs
+++ b/Homestead/Shared/Cards.cs
@@ -41,7 +41,7 @@ namespace Homestead.Shared
         static Cards()
         {
             int lots = 5;
-            //int some = 3;
+            int some = 3;
             int few = 1;
             MasterDeck.Add(new CardInfo(EarthquakeSelf, "Quake: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "earthquake.png", few, Cards.Well));
             //MasterDeck.Add(new CardInfo(EarthquakeOther, "Quake: You", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Other, "earthquake.png", few, Cards.Well));
@@ -59,9 +59,9 @@ namespace Homestead.Shared
             //MasterDeck.Add(new CardInfo(GoodNeighbor, "Give", CardInfo.CardSuit.Action, false, CardInfo.CardImpact.None, "good-neighbor", some));
             //MasterDeck.Add(new CardInfo(BadNeighbor, "Steal", CardInfo.CardSuit.Action, false, CardInfo.CardImpact.None, "bad-neighbor", some));
 
-            //MasterDeck.Add(new CardInfo(Levee, "Levee", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "levee.png", some));
-            //MasterDeck.Add(new CardInfo(Dog, "D.O.G.", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "dog.png", lots));
-            //MasterDeck.Add(new CardInfo(Rain, "Rain", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "rain.png", some));
+            MasterDeck.Add(new CardInfo(Levee, "Levee", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "levee.png", some));
+            MasterDeck.Add(new CardInfo(Dog, "D.O.G.", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "dog.png", lots));
+            MasterDeck.Add(new CardInfo(Rain, "Rain", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "rain.png", some));
 
             MasterDeck.Add(new CardInfo(Livestock, "Animals", CardInfo.CardSuit.LiveStock, true, CardInfo.CardImpact.None, "livestock.png", lots));
             MasterDeck.Add(new CardInfo(Seeds, "Seeds", CardInfo.CardSuit.Garden, true, CardInfo.CardImpact.None, "seeds.png", lots));

--- a/Homestead/Shared/Cards.cs
+++ b/Homestead/Shared/Cards.cs
@@ -42,19 +42,19 @@ namespace Homestead.Shared
         {
             int lots = 5;
             //int some = 3;
-            //int few = 1;
-            //MasterDeck.Add(new CardInfo(EarthquakeSelf, "Quake: Me",CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "earthquake.png", few, Cards.Well));
+            int few = 1;
+            MasterDeck.Add(new CardInfo(EarthquakeSelf, "Quake: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "earthquake.png", few, Cards.Well));
             //MasterDeck.Add(new CardInfo(EarthquakeOther, "Quake: You", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Other, "earthquake.png", few, Cards.Well));
-            //MasterDeck.Add(new CardInfo(EarthquakeAll, "Quake: All",CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.All, "earthquake.png", few, Cards.Well));
-            //MasterDeck.Add(new CardInfo(FireSelf, "Fire: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "fire.png", few, Cards.Wood, Cards.Rain));
+            MasterDeck.Add(new CardInfo(EarthquakeAll, "Quake: All", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.All, "earthquake.png", few, Cards.Well));
+            MasterDeck.Add(new CardInfo(FireSelf, "Fire: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "fire.png", few, Cards.Wood, Cards.Rain));
             //MasterDeck.Add(new CardInfo(FireOther, "Fire: You", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Other, "fire.png", few, Cards.Wood, Cards.Rain));
-            //MasterDeck.Add(new CardInfo(FireAll, "Fire: All", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.All, "fire.png", few, Cards.Wood, Cards.Rain));
-            //MasterDeck.Add(new CardInfo(FloodSelf, "Flood: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "flood.png", few, Cards.Seeds, Cards.Levee));
+            MasterDeck.Add(new CardInfo(FireAll, "Fire: All", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.All, "fire.png", few, Cards.Wood, Cards.Rain));
+            MasterDeck.Add(new CardInfo(FloodSelf, "Flood: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "flood.png", few, Cards.Seeds, Cards.Levee));
             //MasterDeck.Add(new CardInfo(FloodOther, "Flood: You", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Other, "flood.png", few, Cards.Seeds, Cards.Levee));
-            //MasterDeck.Add(new CardInfo(FloodAll, "Flood: All", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.All, "flood.png", few, Cards.Seeds, Cards.Levee));
-            //MasterDeck.Add(new CardInfo(WolfSelf, "Wolf: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "wolf.png", few, Cards.Livestock, Cards.Dog));
+            MasterDeck.Add(new CardInfo(FloodAll, "Flood: All", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.All, "flood.png", few, Cards.Seeds, Cards.Levee));
+            MasterDeck.Add(new CardInfo(WolfSelf, "Wolf: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "wolf.png", few, Cards.Livestock, Cards.Dog));
             //MasterDeck.Add(new CardInfo(WolfOther, "Wolf: You", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Other, "wolf.png", few, Cards.Livestock, Cards.Dog));
-            //MasterDeck.Add(new CardInfo(WolfAll, "Wolf: All", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.All, "wolf.png", few, Cards.Livestock, Cards.Dog));
+            MasterDeck.Add(new CardInfo(WolfAll, "Wolf: All", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.All, "wolf.png", few, Cards.Livestock, Cards.Dog));
 
             //MasterDeck.Add(new CardInfo(GoodNeighbor, "Give", CardInfo.CardSuit.Action, false, CardInfo.CardImpact.None, "good-neighbor", some));
             //MasterDeck.Add(new CardInfo(BadNeighbor, "Steal", CardInfo.CardSuit.Action, false, CardInfo.CardImpact.None, "bad-neighbor", some));
@@ -62,7 +62,7 @@ namespace Homestead.Shared
             //MasterDeck.Add(new CardInfo(Levee, "Levee", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "levee.png", some));
             //MasterDeck.Add(new CardInfo(Dog, "D.O.G.", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "dog.png", lots));
             //MasterDeck.Add(new CardInfo(Rain, "Rain", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "rain.png", some));
-            
+
             MasterDeck.Add(new CardInfo(Livestock, "Animals", CardInfo.CardSuit.LiveStock, true, CardInfo.CardImpact.None, "livestock.png", lots));
             MasterDeck.Add(new CardInfo(Seeds, "Seeds", CardInfo.CardSuit.Garden, true, CardInfo.CardImpact.None, "seeds.png", lots));
             MasterDeck.Add(new CardInfo(Well, "Well", CardInfo.CardSuit.Garden, true, CardInfo.CardImpact.None, "well.png", lots));

--- a/Homestead/Shared/Cards.cs
+++ b/Homestead/Shared/Cards.cs
@@ -27,7 +27,7 @@ namespace Homestead.Shared
         public const string BadNeighbor = "BadNeighbor";
         public const string Levee = "Levee";
         public const string Livestock = "Livestock";
-        public const string Rain = "Raid";
+        public const string Rain = "Rain";
         public const string Saw = "Saw";
         public const string Seeds = "Seeds";
         public const string Shovel = "Shovel";
@@ -40,32 +40,34 @@ namespace Homestead.Shared
 
         static Cards()
         {
-            int lots = 5;
-            int some = 3;
+            int extreme = 20;
+            int tons = 15;
+            int lots = 10;
+            int some = 2;
             int few = 1;
-            MasterDeck.Add(new CardInfo(EarthquakeSelf, "Quake: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "earthquake.png", few, Cards.Well));
-            //MasterDeck.Add(new CardInfo(EarthquakeOther, "Quake: You", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Other, "earthquake.png", few, Cards.Well));
-            MasterDeck.Add(new CardInfo(EarthquakeAll, "Quake: All", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.All, "earthquake.png", few, Cards.Well));
-            MasterDeck.Add(new CardInfo(FireSelf, "Fire: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "fire.png", few, Cards.Wood, Cards.Rain));
+            MasterDeck.Add(new CardInfo(EarthquakeSelf, "Quake: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "earthquake.png", few, Cards.Well, null));
+            //MasterDeck.Add(new CardInfo(EarthquakeOther, "Quake: You", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Other, "earthquake.png", few, Cards.Well, null));
+            MasterDeck.Add(new CardInfo(EarthquakeAll, "Quake: All", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.All, "earthquake.png", few, Cards.Well, null));
+            MasterDeck.Add(new CardInfo(FireSelf, "Fire: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "fire.png", some, Cards.Wood, Cards.Rain));
             //MasterDeck.Add(new CardInfo(FireOther, "Fire: You", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Other, "fire.png", few, Cards.Wood, Cards.Rain));
             MasterDeck.Add(new CardInfo(FireAll, "Fire: All", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.All, "fire.png", few, Cards.Wood, Cards.Rain));
-            MasterDeck.Add(new CardInfo(FloodSelf, "Flood: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "flood.png", few, Cards.Seeds, Cards.Levee));
+            MasterDeck.Add(new CardInfo(FloodSelf, "Flood: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "flood.png", some, Cards.Seeds, Cards.Levee));
             //MasterDeck.Add(new CardInfo(FloodOther, "Flood: You", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Other, "flood.png", few, Cards.Seeds, Cards.Levee));
             MasterDeck.Add(new CardInfo(FloodAll, "Flood: All", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.All, "flood.png", few, Cards.Seeds, Cards.Levee));
-            MasterDeck.Add(new CardInfo(WolfSelf, "Wolf: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "wolf.png", few, Cards.Livestock, Cards.Dog));
+            MasterDeck.Add(new CardInfo(WolfSelf, "Wolf: Me", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Self, "wolf.png", some, Cards.Livestock, Cards.Dog));
             //MasterDeck.Add(new CardInfo(WolfOther, "Wolf: You", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.Other, "wolf.png", few, Cards.Livestock, Cards.Dog));
             MasterDeck.Add(new CardInfo(WolfAll, "Wolf: All", CardInfo.CardSuit.Disaster, false, CardInfo.CardImpact.All, "wolf.png", few, Cards.Livestock, Cards.Dog));
 
             //MasterDeck.Add(new CardInfo(GoodNeighbor, "Give", CardInfo.CardSuit.Action, false, CardInfo.CardImpact.None, "good-neighbor", some));
             //MasterDeck.Add(new CardInfo(BadNeighbor, "Steal", CardInfo.CardSuit.Action, false, CardInfo.CardImpact.None, "bad-neighbor", some));
 
-            MasterDeck.Add(new CardInfo(Levee, "Levee", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "levee.png", some));
-            MasterDeck.Add(new CardInfo(Dog, "D.O.G.", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "dog.png", lots));
-            MasterDeck.Add(new CardInfo(Rain, "Rain", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "rain.png", some));
+            MasterDeck.Add(new CardInfo(Levee, "Levee", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "levee.png", tons));
+            MasterDeck.Add(new CardInfo(Dog, "D.O.G.", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "dog.png", tons));
+            MasterDeck.Add(new CardInfo(Rain, "Rain", CardInfo.CardSuit.Prevention, false, CardInfo.CardImpact.None, "rain.png", tons));
 
             MasterDeck.Add(new CardInfo(Livestock, "Animals", CardInfo.CardSuit.LiveStock, true, CardInfo.CardImpact.None, "livestock.png", lots));
             MasterDeck.Add(new CardInfo(Seeds, "Seeds", CardInfo.CardSuit.Garden, true, CardInfo.CardImpact.None, "seeds.png", lots));
-            MasterDeck.Add(new CardInfo(Well, "Well", CardInfo.CardSuit.Garden, true, CardInfo.CardImpact.None, "well.png", lots));
+            MasterDeck.Add(new CardInfo(Well, "Well", CardInfo.CardSuit.Garden, true, CardInfo.CardImpact.None, "well.png", extreme));
             MasterDeck.Add(new CardInfo(Shovel, "Shovel", CardInfo.CardSuit.Garden, true, CardInfo.CardImpact.None, "shovel.png", lots));
             MasterDeck.Add(new CardInfo(Saw, "Saw", CardInfo.CardSuit.House, true, CardInfo.CardImpact.None, "saw.png", lots));
             MasterDeck.Add(new CardInfo(Hammer, "Hammer", CardInfo.CardSuit.House, true, CardInfo.CardImpact.None, "hammer.png", lots));

--- a/Homestead/Shared/Game.cs
+++ b/Homestead/Shared/Game.cs
@@ -23,6 +23,7 @@ namespace Homestead.Shared
         public int ActivePlayer { get; set; } = 1;
         public List<PlayerAction> AvailableActions { get; set; } = new ();
         public List<PlayerAction> LastActions { get; set; } = new();
+        public string? LastPlayedCard { get; set; }
 
         public DateTime LastPlayDate { get; set; } = DateTime.UtcNow;
     }

--- a/Homestead/Shared/GameEngineWithActions.cs
+++ b/Homestead/Shared/GameEngineWithActions.cs
@@ -3,7 +3,7 @@ using static Homestead.Shared.PlayerAction;
 
 namespace Homestead.Shared
 {
-    public class GameEngineWithActions : GameEngine
+    public class GameEngineWithActions : IGameEngine
     {
         /// <summary>
         /// Creates a new game instance and returns it ready for play.<br />

--- a/Homestead/Shared/GameEngineWithActions.cs
+++ b/Homestead/Shared/GameEngineWithActions.cs
@@ -48,7 +48,10 @@ namespace Homestead.Shared
                     return new ActionDrawDiscardCard(game);
                 case ActionType.DrawFromDeck:
                     return new ActionDrawDeckCard(game);
+                case ActionType.EndTurn:
+                    return new ActionEndTurn(game);
                 default:
+                    // TODO: Make this better handled on the client
                     throw new ArgumentException($"No action found for enum {type}");
             }
         }

--- a/Homestead/Shared/GameEngineWithActions.cs
+++ b/Homestead/Shared/GameEngineWithActions.cs
@@ -1,0 +1,102 @@
+﻿using Homestead.Shared.Actions;
+using static Homestead.Shared.PlayerAction;
+
+namespace Homestead.Shared
+{
+    public class GameEngineWithActions : GameEngine
+    {
+        /// <summary>
+        /// Creates a new game instance and returns it ready for play.<br />
+        /// Assumes the active player is player 1 with the only available actions as Draw from Deck.<br />
+        /// Player 1 must not be a bot.
+        /// </summary>
+        /// <returns></returns>
+        public Game Start(string playerId)
+        {
+            Game game = new();
+            game.GameId = Guid.NewGuid().ToString();
+            const int firstPlayer = 1;
+
+            // Create 4 players
+            for (int i = firstPlayer; i <= 4; i++)
+            {
+                var player = new Player(i);
+                if (i == firstPlayer)
+                {
+                    player.PlayerId = playerId;
+                }
+                else
+                {
+                    player.IsBot = true;
+                }
+                game.Players.Add(player);
+            }
+            game.ActivePlayer = firstPlayer;
+            game.AvailableActions.Add(new PlayerAction(PlayerAction.ActionType.DrawFromDeck, firstPlayer));
+            return game;
+        }
+
+        private static ActionBase GetAction(ActionType type, Game game)
+        {
+            switch (type)
+            {
+                case ActionType.Play:
+                    return new ActionPlayCard(game);
+                case ActionType.Discard:
+                    return new ActionDiscardCard(game);
+                case ActionType.DrawFromDiscard:
+                    return new ActionDrawDiscardCard(game);
+                case ActionType.DrawFromDeck:
+                    return new ActionDrawDeckCard(game);
+                default:
+                    throw new ArgumentException($"No action found for enum {type}");
+            }
+        }
+
+        /// <summary>
+        /// Takes an action and updates the game state of the game passed in
+        /// </summary>
+        /// <param name="game"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        /// <exception cref="NullReferenceException"></exception>
+        public Game ProcessAction(Game game, PlayerAction action)
+        {
+            ActionBase actionRunner = GetAction(action.Type, game);
+            game.LastActions.Clear();
+            if (actionRunner != null)
+            {
+                actionRunner.Run(action);
+            }
+            game.LastActions.Add(action);
+
+            // Check and Set winner
+            CheckAndSetWinner(game);
+
+            game.LastPlayDate = DateTime.UtcNow;
+            return game;
+        }
+
+
+        private void CheckAndSetWinner(Game game)
+        {
+            foreach (var player in game.Players)
+            {
+                if (player.Board.Contains(Cards.Livestock)
+                    && player.Board.Contains(Cards.Seeds)
+                    && player.Board.Contains(Cards.Well)
+                    && player.Board.Contains(Cards.Shovel)
+                    && player.Board.Contains(Cards.Saw)
+                    && player.Board.Contains(Cards.Hammer)
+                    && player.Board.Contains(Cards.Wood)
+                    && player.Board.Contains(Cards.Stove))
+                {
+                    game.State = Game.GameState.Complete;
+                    game.Winner = game.ActivePlayer;
+                    game.AvailableActions.Clear();
+                }
+            }
+        }
+    }
+}

--- a/Homestead/Shared/GameEngineWithActions.cs
+++ b/Homestead/Shared/GameEngineWithActions.cs
@@ -86,14 +86,7 @@ namespace Homestead.Shared
         {
             foreach (var player in game.Players)
             {
-                if (player.Board.Contains(Cards.Livestock)
-                    && player.Board.Contains(Cards.Seeds)
-                    && player.Board.Contains(Cards.Well)
-                    && player.Board.Contains(Cards.Shovel)
-                    && player.Board.Contains(Cards.Saw)
-                    && player.Board.Contains(Cards.Hammer)
-                    && player.Board.Contains(Cards.Wood)
-                    && player.Board.Contains(Cards.Stove))
+                if (player.Board.Count(c => Cards.GetCardInfo(c).RequiredToWin) == 8)
                 {
                     game.State = Game.GameState.Complete;
                     game.Winner = game.ActivePlayer;

--- a/Homestead/Shared/PlayerAction.cs
+++ b/Homestead/Shared/PlayerAction.cs
@@ -24,6 +24,9 @@ namespace Homestead.Shared
         public string? PlayerCard { get; set; }
         public int? TargetPlayer { get; set; }
         public string? TargetCard { get; set; }
+        // TODO: Set these up on the server and the client.
+        public bool PlayerSelectionRequired { get; set; }
+        public bool PlayerCardSelectionRequired { get; set; }
         
         public PlayerAction(ActionType type, int playerNumber, string? PlayerCard = null, int? TargetPlayer = null, string? TargetCard = null)
         {

--- a/Homestead/Shared/PlayerAction.cs
+++ b/Homestead/Shared/PlayerAction.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static System.Collections.Specialized.BitVector32;
 
 namespace Homestead.Shared
 {
@@ -35,6 +36,34 @@ namespace Homestead.Shared
             this.PlayerCard = PlayerCard;
             this.TargetPlayer = TargetPlayer;
             this.TargetCard = TargetCard;
+        }
+
+        public string ToString(Game game)
+        {
+            string result = $"Player {PlayerNumber}: {game.Players[PlayerNumber - 1].Name} ";
+            result += $"{(game.Players[PlayerNumber - 1].IsBot ? "the bot " : "")}";
+            switch (Type)
+            {
+                case PlayerAction.ActionType.DrawFromDeck:
+                    result += "drew from the deck";
+                    break;
+                case PlayerAction.ActionType.DrawFromDiscard:
+                    result += "drew from the discard pile";
+                    break;
+                case PlayerAction.ActionType.Play:
+                    result += $"played the card '{PlayerCard}'";
+                    break;
+                case PlayerAction.ActionType.EndTurn:
+                    result += "ended their turn";
+                    break;
+                case PlayerAction.ActionType.Discard:
+                    result += $"discarded a {PlayerCard}";
+                    break;
+                default:
+                    result += "did something interesting";
+                    break;
+            }
+            return result;
         }
     }
 }

--- a/Homestead/Shared/PlayerAction.cs
+++ b/Homestead/Shared/PlayerAction.cs
@@ -65,5 +65,6 @@ namespace Homestead.Shared
             }
             return result;
         }
+        public bool IsDisaster => Type == ActionType.Play && Cards.GetCardInfo(PlayerCard!).Suit == CardInfo.CardSuit.Disaster ;
     }
 }

--- a/Homestead/Shared/PlayerAction.cs
+++ b/Homestead/Shared/PlayerAction.cs
@@ -51,13 +51,13 @@ namespace Homestead.Shared
                     result += "drew from the discard pile";
                     break;
                 case PlayerAction.ActionType.Play:
-                    result += $"played the card '{PlayerCard}'";
+                    result += $"played the card '{Cards.GetCardInfo(PlayerCard!).Name}'";
                     break;
                 case PlayerAction.ActionType.EndTurn:
                     result += "ended their turn";
                     break;
                 case PlayerAction.ActionType.Discard:
-                    result += $"discarded a {PlayerCard}";
+                    result += $"discarded a {Cards.GetCardInfo(PlayerCard!).Name}";
                     break;
                 default:
                     result += "did something interesting";


### PR DESCRIPTION
I rewrote the engine using an action framework where each action has a class that carries out the work. 
I also added Disaster Me/All and Prevention cards to the deck. 
The idea of having to put a disaster on another player isn't here because I didn't implement that logic on the client side or for the bots. The server logic exists. 
I left all the unit tests in place for the old engine but didn't create new ones.
I did some game rebalancing for card frequency so that game stayed fun and winnable in a decent timeframe.

Fully addresses: #23 
Partially addresses: #16 